### PR TITLE
Add missing return

### DIFF
--- a/src/OTA-Hub-diy.hpp
+++ b/src/OTA-Hub-diy.hpp
@@ -209,6 +209,7 @@ namespace OTA
                 }
             }
             Serial.println("The latest release contains no firmware asset. We can't continue...");
+            return return_object;
         }
 
         Serial.println("Failed to connect to GitHub. Check your OTAGH_... #defines.");


### PR DESCRIPTION
Without this return, when the found release has no firmware asset, confusing message "Failed to connect to GitHub" is shown.