### PR TITLE
Make condition_strings array match enum order

### DIFF
--- a/src/OTA-Hub-diy.hpp
+++ b/src/OTA-Hub-diy.hpp
@@ -96,8 +96,8 @@ namespace OTA
             const char *condition_strings[] = {
                 "NO_UPDATE",
                 "OLD_DIFFERENT",
-                "NEW_DIFFERENT",
-                "NEW_SAME"};
+                "NEW_SAME",
+                "NEW_DIFFERENT"};
 
             // Print condition
             print_stream->println("------------------------");


### PR DESCRIPTION
UpdateCondition enumeration and condition_strings array need to have the same order, otherwise the wrong condition will be printed from details.print()